### PR TITLE
修复RCTMJScrollView 有时会Crash问题   lower

### DIFF
--- a/ios/RCTMJRefreshHeader/RCTMJRefreshHeader/RCTMJScrollView.m
+++ b/ios/RCTMJRefreshHeader/RCTMJRefreshHeader/RCTMJScrollView.m
@@ -507,7 +507,9 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(UIView *view, 
 - (void)dealloc
 {
     _scrollView.delegate = nil;
-    [_eventDispatcher.bridge.uiManager.observerCoordinator removeObserver:self];
+    if (_maintainVisibleContentPosition != nil) {
+        [_eventDispatcher.bridge.uiManager.observerCoordinator removeObserver:self];
+    }
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
当没有addObserver，执行dealloc方法，移除 Observer 会发生Crash